### PR TITLE
handle removed fd

### DIFF
--- a/metrics/sockets.go
+++ b/metrics/sockets.go
@@ -25,6 +25,8 @@ func getSocketCount() uint64 {
 	hasLogged := false
 	for _, fd := range fds {
 		sl, err := os.Readlink(fmt.Sprintf("%s/%s", base, fd.Name()))
+		// The fd opened by ReadDir is often closed at this point.
+		// In general, fds may close between the check and readlink and we should ignore those
 		if err != nil && !strings.HasSuffix(err.Error(), "no such file or directory") {
 			if !hasLogged {
 				lg.ErrorD("failed-readlink", logger.M{"err": err.Error()})

--- a/metrics/sockets.go
+++ b/metrics/sockets.go
@@ -25,7 +25,7 @@ func getSocketCount() uint64 {
 	hasLogged := false
 	for _, fd := range fds {
 		sl, err := os.Readlink(fmt.Sprintf("%s/%s", base, fd.Name()))
-		if err != nil {
+		if err != nil && !strings.HasSuffix(err.Error(), "no such file or directory") {
 			if !hasLogged {
 				lg.ErrorD("failed-readlink", logger.M{"err": err.Error()})
 				hasLogged = true


### PR DESCRIPTION
The file could have been removed since we checked. Also, ReadDir opens a FD that is often closed by this point.